### PR TITLE
chore(deps): upgrade typescript to v6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@vitejs/plugin-react": "^5.2.0",
     "baseline-browser-mapping": "^2.10.34",
     "jsdom": "^27.4.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "ultracite": "7.8.2",
     "vite": "^7.3.5",
     "vitest": "^4.1.8",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
TypeScript 6.0 changes the default value of the `strict` flag from false to true, deprecates ES3/ES5 targets, and deprecates `import assert` in favor of `import with`.

**Changes:**
- Upgraded typescript from 5.9.3 to 6.0.3
- Added `ignoreDeprecations: "6.0"` to tsconfig.json to suppress deprecation warnings

**Note:** The project already has `strict: true` in tsconfig.json, so the default change has no impact. The `ignoreDeprecations` flag allows a gradual migration to new syntax patterns.